### PR TITLE
Fix future deprecated

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Backend/Monitoring&QA

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Backend/Monitoring&QA
+* @Backend/Api

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -5,18 +5,9 @@ namespace M6Web\Bundle\GuzzleHttpBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-/**
- * This is the class that validates and merges configuration from your app/config files
- *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
- */
 class Configuration implements ConfigurationInterface
 {
-    /**
-     * http://symfony.com/fr/doc/current/components/config/definition.html
-     * {@inheritdoc}
-     */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('m6web_guzzlehttp');
 

--- a/src/M6WebGuzzleHttpBundle.php
+++ b/src/M6WebGuzzleHttpBundle.php
@@ -4,17 +4,15 @@ namespace M6Web\Bundle\GuzzleHttpBundle;
 
 use M6Web\Bundle\GuzzleHttpBundle\DependencyInjection\MiddlewarePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * Class M6WebCassandraBundle
- */
 class M6WebGuzzleHttpBundle extends Bundle
 {
     /**
      * {@inheritdoc}
      */
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         return new DependencyInjection\M6WebGuzzleHttpExtension();
     }


### PR DESCRIPTION
## Why?
I have some deprecations notice from phpunit when using this bundle on a PHP 8 project.
This PR aim fix them.

```
 1x: Method "Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension()" might add "?ExtensionInterface" as a native return type declaration in the future. Do the same in child class "M6Web\Bundle\GuzzleHttpBundle\M6WebGuzzleHttpBundle" now to avoid errors or add an explicit @return annotation to suppress this message.
  1x: Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\GuzzleHttpBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.
```

## How?
- Add proper function return types on `Configuration.php` and `M6WebGuzzleHttpBundle` classes
- Add code owners for this bundle

