### PR TITLE
fix(dataCollector): fix default index

### DIFF
--- a/src/DataCollector/GuzzleHttpDataCollector.php
+++ b/src/DataCollector/GuzzleHttpDataCollector.php
@@ -67,10 +67,9 @@ class GuzzleHttpDataCollector extends DataCollector
     public function onGuzzleHttpCommand(AbstractGuzzleHttpEvent $event)
     {
         $client = 'm6web_guzzlehttp';
-        if($event->getClientId() !== 'default'){
+        if ($event->getClientId() !== 'default') {
             $client = $client.'_'.$event->getClientId();
         }
-
 
         $request = $event->getRequest();
         $response = $event->getResponse();

--- a/src/DataCollector/GuzzleHttpDataCollector.php
+++ b/src/DataCollector/GuzzleHttpDataCollector.php
@@ -66,7 +66,11 @@ class GuzzleHttpDataCollector extends DataCollector
      */
     public function onGuzzleHttpCommand(AbstractGuzzleHttpEvent $event)
     {
-        $client = 'm6web_guzzlehttp_'.$event->getClientId();
+        $client = 'm6web_guzzlehttp';
+        if($event->getClientId() !== 'default'){
+            $client = $client.'_'.$event->getClientId();
+        }
+
 
         $request = $event->getRequest();
         $response = $event->getResponse();

--- a/src/DataCollector/GuzzleHttpDataCollector.php
+++ b/src/DataCollector/GuzzleHttpDataCollector.php
@@ -68,7 +68,7 @@ class GuzzleHttpDataCollector extends DataCollector
     {
         $client = 'm6web_guzzlehttp';
         if ($event->getClientId() !== 'default') {
-            $client = $client.'_'.$event->getClientId();
+            $client .= '_'.$event->getClientId();
         }
 
         $request = $event->getRequest();


### PR DESCRIPTION
## Why?
Because default client is name without |`_key`

