### PR TITLE
fix(DataCollector): depend on client interface instead of client im…

### DIFF
--- a/src/DataCollector/GuzzleHttpDataCollector.php
+++ b/src/DataCollector/GuzzleHttpDataCollector.php
@@ -2,7 +2,7 @@
 
 namespace M6Web\Bundle\GuzzleHttpBundle\DataCollector;
 
-use GuzzleHttp\Client as GuzzleHttpClient;
+use GuzzleHttp\ClientInterface as GuzzleHttpClient;
 use M6Web\Bundle\GuzzleHttpBundle\EventDispatcher\AbstractGuzzleHttpEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
…plementation

## Why?
DataCollector depends on client implementation instead of client interface

## How?
Use interface instead of implementation

