### PR TITLE
fix: forward header host to guzzle client

### DIFF
--- a/src/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/src/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -85,8 +85,14 @@ class M6WebGuzzleHttpExtension extends Extension
         $middlewareEventDispatcherDefinition->setArguments([new Reference('event_dispatcher'), $clientId]);
         $middlewareEventDispatcherDefinition->addMethodCall('push', [$handlerStackReference]);
 
+        $middlewareHostForwarderDefinition = new Definition('%m6web_guzzlehttp.middleware.hostforwarder.class%');
+        $middlewareHostForwarderDefinition->setPublic(true);
+        $middlewareHostForwarderDefinition->setArguments([$config]);
+        $middlewareHostForwarderDefinition->addMethodCall('push', [$handlerStackReference]);
+
         // we must assign middleware for build process
         $config['middleware'][] = $middlewareEventDispatcherDefinition;
+        $config['middleware'][] = $middlewareHostForwarderDefinition;
         $config['handler'] = $handlerStackReference;
 
         if ($config['redirect_handler'] == 'curl') {

--- a/src/Middleware/HostForwarderMiddleware.php
+++ b/src/Middleware/HostForwarderMiddleware.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace M6Web\Bundle\GuzzleHttpBundle\Middleware;
+
+use GuzzleHttp\HandlerStack;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Middleware to forward a configured header "host".
+ */
+class HostForwarderMiddleware implements MiddlewareInterface
+{
+    protected array $config;
+
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Push function to middleware handler
+     */
+    public function push(HandlerStack $stack): HandlerStack
+    {
+        $stack->push(function (callable $handler) {
+            return function (
+                RequestInterface $request,
+                array $options
+            ) use ($handler) {
+                if (isset($this->config['headers'])) {
+                    $lowercaseHeaders = array_change_key_case($this->config['headers']);
+                    if (isset($lowercaseHeaders['host'])) {
+                        $request = $request->withHeader('host', $lowercaseHeaders['host']);
+                    }
+                }
+
+                return $handler($request, $options);
+            };
+        }, 'hostForwarder_forward');
+
+        return $stack;
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -8,6 +8,7 @@ parameters:
     m6web_guzzlehttp.guzzle.client.class: 'GuzzleHttp\Client'
 
     m6web_guzzlehttp.middleware.eventdispatcher.class: 'M6Web\Bundle\GuzzleHttpBundle\Middleware\EventDispatcherMiddleware'
+    m6web_guzzlehttp.middleware.hostforwarder.class: 'M6Web\Bundle\GuzzleHttpBundle\Middleware\HostForwarderMiddleware'
 
 services:
 

--- a/tests/Units/Middleware/HostForwarderMiddleware.php
+++ b/tests/Units/Middleware/HostForwarderMiddleware.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace M6Web\Bundle\GuzzleHttpBundle\tests\Units\Middleware;
+
+use M6Web\Bundle\GuzzleHttpBundle\Middleware\HostForwarderMiddleware as Base;
+
+/**
+ * Class HostForwarderMiddleware test
+ */
+class HostForwarderMiddleware extends \atoum
+{
+    /**
+     * @dataProvider pushHostForwarderDataProvider
+     */
+    public function testPushHostForwarder(array $configuration, int $expectedNumberOfCalls)
+    {
+        // Mock HandlerStack
+        $eventCallable = null;
+        $handlerStackMock = new \mock\GuzzleHttp\HandlerStack();
+        $handlerStackMock->getMockController()->push = function ($callable, $str) use (&$eventCallable) {
+            if ($str == 'hostForwarder_forward') {
+                $eventCallable = $callable;
+            }
+        };
+
+        // Response & request
+        $requestMock = new \mock\Psr\Http\Message\RequestInterface();
+
+        // Mock guzzle promise
+        $promiseMock = new \mock\GuzzleHttp\Promise();
+        $promiseMock->getMockController()->then = function ($success, $error) use (&$successCallable, &$errorCallable) {
+            $successCallable = $success;
+            $errorCallable = $error;
+        };
+
+        // Handler for end of event
+        $handlerEvent = function () use ($promiseMock) {
+            return $promiseMock;
+        };
+
+        $this
+            ->if($hostForwarderMiddleware = new Base($configuration))
+            ->then
+                ->object($hostForwarderMiddleware->push($handlerStackMock))
+                    ->isEqualTo($handlerStackMock)
+                ->mock($handlerStackMock)
+                    ->call('push')
+                        ->once()
+                ->object($callableHandler = $eventCallable($handlerEvent))
+                    ->isCallable()
+                ->variable($callableHandler($requestMock, []))
+                    ->isNotNull()
+                ->mock($promiseMock)
+                    ->call('then')
+                        ->never()
+                ->mock($requestMock)
+                    ->call('withHeader')
+                        ->exactly($expectedNumberOfCalls)
+                        ->withArguments('host', 'my_configured_host')
+        ;
+    }
+
+    protected function pushHostForwarderDataProvider(): array
+    {
+        return [
+            [
+                'configuration' => [
+                    'headers' => [
+                        'host' => 'my_configured_host',
+                    ],
+                ],
+                'expectedNumberOfCalls' => 1,
+            ],
+            [
+                'configuration' => [
+                    'headers' => [
+                        'HOST' => 'my_configured_host',
+                    ],
+                ],
+                'expectedNumberOfCalls' => 1,
+            ],
+            [
+                'configuration' => [
+                    'headers' => [],
+                ],
+                'expectedNumberOfCalls' => 0,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Why?
We forgot once to forward the header host to a client, so we updated the bundle to automate this

## How?
Add a new middleware to forward the header `host` to the client if provided in the bundle's configuration

