### PR TITLE
chore: mark class as deprecated before next major version

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -8,6 +8,9 @@ use GuzzleHttp\Handler\EasyHandle;
 
 /**
  * Extends the Guzzle curl factory to set curl info in response
+ *
+ * @deprecated the curlInfo dynamic property will be deleted
+ * in favor of [the native on_stat option](https://docs.guzzlephp.org/en/latest/request-options.html#on-stats)
  */
 class CurlFactory extends GuzzleCurlFactory
 {


### PR DESCRIPTION
## Why?

The curlInfo dynamic property is deprecated in PHP8.2 and will be removed in favor of [the native `on_stat` option](https://docs.guzzlephp.org/en/latest/request-options.html#on-stats)

## How?

`@deprecated` should trigger warnings in CI to notice people about this change

