### PR TITLE
fix: fixed php-cs-fixer version and applied coding style

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "atoum/atoum": "4.0.3",
     "atoum/stubs": "*",
     "m6web/php-cs-fixer-config": "2.0.0",
-    "friendsofphp/php-cs-fixer": "3.34.1"
+    "friendsofphp/php-cs-fixer": "3.34.1",
+    "guzzlehttp/promises": "^1"
   },
   "autoload": {
     "psr-4": {"M6Web\\Bundle\\GuzzleHttpBundle\\": "src/"}

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
   "require-dev": {
     "atoum/atoum": "4.0.3",
     "atoum/stubs": "*",
-    "m6web/php-cs-fixer-config": "2.0.0"
+    "m6web/php-cs-fixer-config": "2.0.0",
+    "friendsofphp/php-cs-fixer": "3.34.1"
   },
   "autoload": {
     "psr-4": {"M6Web\\Bundle\\GuzzleHttpBundle\\": "src/"}

--- a/src/Cache/InMemory.php
+++ b/src/Cache/InMemory.php
@@ -10,9 +10,6 @@ class InMemory implements CacheInterface
     protected $cache = [];
     protected $ttl = [];
 
-    /**
-     * {@inheritdoc}
-     */
     public function has($key)
     {
         if (array_key_exists($key, $this->cache)) {
@@ -25,9 +22,6 @@ class InMemory implements CacheInterface
         return false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function get($key)
     {
         if ($this->has($key)) {
@@ -37,18 +31,12 @@ class InMemory implements CacheInterface
         return null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function set($key, $value, $ttl = null)
     {
         $this->cache[$key] = $value;
         $this->ttl[$key] = is_null($ttl) ? null : microtime(true) + $ttl;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function remove($key)
     {
         unset(
@@ -57,9 +45,6 @@ class InMemory implements CacheInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function ttl($key)
     {
         if ($this->has($key)) {

--- a/src/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/src/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -16,9 +16,6 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class M6WebGuzzleHttpExtension extends Extension
 {
-    /**
-     * {@inheritdoc}
-     */
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();

--- a/src/Handler/CacheTrait.php
+++ b/src/Handler/CacheTrait.php
@@ -106,8 +106,6 @@ trait CacheTrait
      * Cache response
      *
      * @param int $ttl
-     *
-     * @return mixed
      */
     protected function cacheResponse(RequestInterface $request, Response $response, $ttl = null)
     {

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -11,9 +11,6 @@ use GuzzleHttp\Handler\EasyHandle;
  */
 class CurlFactory extends GuzzleCurlFactory
 {
-    /**
-     * {@inheritdoc}
-     */
     public function release(EasyHandle $easy): void
     {
         if (!is_null($easy->response)) {

--- a/src/M6WebGuzzleHttpBundle.php
+++ b/src/M6WebGuzzleHttpBundle.php
@@ -10,17 +10,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class M6WebGuzzleHttpBundle extends Bundle
 {
-    /**
-     * {@inheritdoc}
-     */
     public function getContainerExtension(): ?ExtensionInterface
     {
         return new DependencyInjection\M6WebGuzzleHttpExtension();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function build(ContainerBuilder $container)
     {
         parent::build($container);

--- a/src/Middleware/EventDispatcherMiddleware.php
+++ b/src/Middleware/EventDispatcherMiddleware.php
@@ -93,8 +93,6 @@ class EventDispatcherMiddleware implements MiddlewareInterface
 
     /**
      * Dispatch event
-     *
-     * @param mixed $reason
      */
     protected function sendErrorEvent(RequestInterface $request, $reason)
     {


### PR DESCRIPTION
## Why?

CI is failing on master due to coding style changes & new major version on `guzzlehttp/promises`

## How?

* Fixed `friendsofphp/php-cs-fixer` version to avoid random changes, and applied it
* Require `guzzlehttp/promises` in tests up to version 1

