### PR TITLE
feat!: update all dependencies to latest supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
       - run: composer install --prefer-dist --no-interaction
       - run: bin/php-cs-fixer fix --ansi --dry-run --using-cache=no --verbose
 
-  tests:
-    name: Tests
+  atoum-tests:
+    name: Atoum tests
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        version: [ '7.4', '8.0', '8.1' ]
+        version: [ 8.1, 8.2 ]
         flags: [ '', '--prefer-lowest' ]
       fail-fast: false
     steps:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ try {
         'second' => $client->getAsync('http://domain.tld/path/to/other/resource')
     ];
 
-    $result = \GuzzleHttp\Promise\unwrap($promises);
+    $result = \GuzzleHttp\Promise\Utils::unwrap($promises);
 } catch(\GuzzleHttp\Exception\ConnectException $e) {
     // connection problem like timeout
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "m6web/guzzle-http-bundle",
   "type" : "symfony-bundle",
-  "description": "Symfony2 bundle on top of guzzle 6",
+  "description": "Symfony bundle on top of Guzzle",
   "keywords": ["bundle", "http", "client", "HTTP client"],
   "license" : "MIT",
   "authors": [
@@ -12,21 +12,21 @@
     }
   ],
   "require": {
-    "php": ">=7.4",
+    "php": ">=8.1",
     "ext-curl": "*",
-    "guzzlehttp/guzzle": "^6.3||^7.0",
-    "symfony/config" : "^4.4||^5.0||^6.0",
-    "symfony/dependency-injection": "^4.4||^5.0||^6.0",
-    "symfony/event-dispatcher": "^4.4||^5.0||^6.0",
-    "symfony/http-kernel": "^4.4||^5.0||^6.0",
-    "symfony/yaml" : "^4.4||^5.0||^6.0"
+    "guzzlehttp/guzzle": "^7",
+    "symfony/config" : "^5.4||^6.0",
+    "symfony/dependency-injection": "^5.4||^6.0",
+    "symfony/event-dispatcher": "^5.4||^6.0",
+    "symfony/http-kernel": "^5.4||^6.0",
+    "symfony/yaml" : "^5.4||^6.0"
   },
   "require-dev": {
-    "atoum/atoum": "4.0.3",
+    "atoum/atoum": "4.2.0",
     "atoum/stubs": "*",
-    "m6web/php-cs-fixer-config": "2.0.0",
-    "friendsofphp/php-cs-fixer": "3.34.1",
-    "guzzlehttp/promises": "^1"
+    "m6web/php-cs-fixer-config": "3.2.0",
+    "friendsofphp/php-cs-fixer": "3.35.1",
+    "guzzlehttp/promises": "^2"
   },
   "autoload": {
     "psr-4": {"M6Web\\Bundle\\GuzzleHttpBundle\\": "src/"}

--- a/src/Cache/CacheInterface.php
+++ b/src/Cache/CacheInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\Cache;
 
 /**

--- a/src/Cache/InMemory.php
+++ b/src/Cache/InMemory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\Cache;
 
 /**
@@ -12,8 +14,8 @@ class InMemory implements CacheInterface
 
     public function has($key)
     {
-        if (array_key_exists($key, $this->cache)) {
-            if (is_null($this->ttl[$key]) || $this->ttl[$key] > microtime(true)) {
+        if (\array_key_exists($key, $this->cache)) {
+            if (\is_null($this->ttl[$key]) || $this->ttl[$key] > microtime(true)) {
                 return true;
             }
             $this->remove($key);
@@ -34,7 +36,7 @@ class InMemory implements CacheInterface
     public function set($key, $value, $ttl = null)
     {
         $this->cache[$key] = $value;
-        $this->ttl[$key] = is_null($ttl) ? null : microtime(true) + $ttl;
+        $this->ttl[$key] = \is_null($ttl) ? null : microtime(true) + $ttl;
     }
 
     public function remove($key)
@@ -48,7 +50,7 @@ class InMemory implements CacheInterface
     public function ttl($key)
     {
         if ($this->has($key)) {
-            if (!is_null($this->ttl[$key])) {
+            if (!\is_null($this->ttl[$key])) {
                 return (int) round($this->ttl[$key] - microtime(true));
             }
 

--- a/src/DataCollector/GuzzleHttpDataCollector.php
+++ b/src/DataCollector/GuzzleHttpDataCollector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\DataCollector;
 
 use GuzzleHttp\ClientInterface as GuzzleHttpClient;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -51,7 +53,7 @@ class Configuration implements ConfigurationInterface
                             ->variableNode('cert')
                                 ->validate()
                                     ->ifTrue(function ($v) {
-                                        return !is_string($v) && (!is_array($v) || count($v) != 2);
+                                        return !\is_string($v) && (!\is_array($v) || \count($v) != 2);
                                     })
                                     ->theninvalid('Requires a string or a two entries array')
                                 ->end()
@@ -59,7 +61,7 @@ class Configuration implements ConfigurationInterface
                             ->variableNode('debug')
                                 ->validate()
                                     ->ifTrue(function ($v) {
-                                        return !is_string($v) && !is_bool($v);
+                                        return !\is_string($v) && !\is_bool($v);
                                     })
                                     ->theninvalid('Requires an invokable service id or a bolean value')
                                 ->end()
@@ -67,7 +69,7 @@ class Configuration implements ConfigurationInterface
                             ->variableNode('decode_content')
                                 ->validate()
                                     ->ifTrue(function ($v) {
-                                        return !is_string($v) && !is_bool($v);
+                                        return !\is_string($v) && !\is_bool($v);
                                     })
                                     ->theninvalid('Requires a string or a boolean')
                                 ->end()
@@ -76,7 +78,7 @@ class Configuration implements ConfigurationInterface
                             ->variableNode('expect')
                                 ->validate()
                                     ->ifTrue(function ($v) {
-                                        return !is_int($v) && !is_bool($v);
+                                        return !\is_int($v) && !\is_bool($v);
                                     })
                                     ->theninvalid('Requires an integer or a boolean')
                                 ->end()
@@ -90,7 +92,7 @@ class Configuration implements ConfigurationInterface
                             ->variableNode('cookies')
                                 ->validate()
                                     ->ifTrue(function ($v) {
-                                        return !is_array($v) && !is_bool($v);
+                                        return !\is_array($v) && !\is_bool($v);
                                     })
                                     ->theninvalid('Requires an array or a boolean')
                                 ->end()
@@ -113,7 +115,7 @@ class Configuration implements ConfigurationInterface
                             ->variableNode('proxy')
                                 ->validate()
                                     ->ifTrue(function ($v) {
-                                        return !is_array($v) && !is_string($v);
+                                        return !\is_array($v) && !\is_string($v);
                                     })
                                     ->theninvalid('Requires an array or a string')
                                 ->end()
@@ -126,7 +128,7 @@ class Configuration implements ConfigurationInterface
                             ->variableNode('ssl_key')
                                 ->validate()
                                     ->ifTrue(function ($v) {
-                                        return !is_string($v) && (!is_array($v) || count($v) != 2);
+                                        return !\is_string($v) && (!\is_array($v) || \count($v) != 2);
                                     })
                                     ->theninvalid('Requires a string or a two entries array')
                                 ->end()
@@ -136,7 +138,7 @@ class Configuration implements ConfigurationInterface
                             ->variableNode('verify')
                                 ->validate()
                                     ->ifTrue(function ($v) {
-                                        return !is_string($v) && !is_bool($v);
+                                        return !\is_string($v) && !\is_bool($v);
                                     })
                                     ->theninvalid('Requires a string or a boolean')
                                 ->end()

--- a/src/DependencyInjection/GuzzleHttpPass.php
+++ b/src/DependencyInjection/GuzzleHttpPass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/src/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/src/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
@@ -50,7 +52,7 @@ class M6WebGuzzleHttpExtension extends Extension
     {
         // clear empty arrays
         foreach ($config as $key => $item) {
-            if (is_array($item) && count($item) == 0) {
+            if (\is_array($item) && \count($item) == 0) {
                 unset($config[$key]);
             }
         }
@@ -110,7 +112,7 @@ class M6WebGuzzleHttpExtension extends Extension
             }
         }
         // Create cookies jar if required
-        if (!empty($config['cookies']) && is_array($config['cookies'])) {
+        if (!empty($config['cookies']) && \is_array($config['cookies'])) {
             $config['cookies'] = $this->getCookiesJarServiceReference($container, $config['cookies'], $clientId);
         }
 
@@ -126,7 +128,7 @@ class M6WebGuzzleHttpExtension extends Extension
         // Services entries
         foreach (['on_headers', 'on_stats'] as $key) {
             if (!empty($config[$key])) {
-                if (is_null($serviceReference = $this->getServiceReference($config[$key]))) {
+                if (\is_null($serviceReference = $this->getServiceReference($config[$key]))) {
                     throw new \InvalidArgumentException(sprintf('"%s" configuration entry requires a valid service reference, "%s" given', $key, $config[$key]));
                 }
                 $config[$key] = $serviceReference;
@@ -171,7 +173,7 @@ class M6WebGuzzleHttpExtension extends Extension
         if (isset($config['guzzlehttp_cache'])) {
             if (
                 !isset($config['guzzlehttp_cache']['service'])
-                || is_null($cacheService = $this->getServiceReference($config['guzzlehttp_cache']['service']))
+                || \is_null($cacheService = $this->getServiceReference($config['guzzlehttp_cache']['service']))
             ) {
                 throw new \InvalidArgumentException(sprintf('"guzzlehttp_cache.service" requires a valid service reference, "%s" given', $config['guzzlehttp_cache']['service']));
             }
@@ -218,11 +220,11 @@ class M6WebGuzzleHttpExtension extends Extension
 
             $protocols = array_map('strtolower', $config['allow_redirects']['protocols']);
 
-            if (in_array('http', $protocols)) {
+            if (\in_array('http', $protocols)) {
                 $redirProtocols |= CURLPROTO_HTTP;
             }
 
-            if (in_array('https', $protocols)) {
+            if (\in_array('https', $protocols)) {
                 $redirProtocols |= CURLPROTO_HTTPS;
             }
 

--- a/src/DependencyInjection/MiddlewarePass.php
+++ b/src/DependencyInjection/MiddlewarePass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/src/EventDispatcher/AbstractGuzzleCacheEvent.php
+++ b/src/EventDispatcher/AbstractGuzzleCacheEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\EventDispatcher;
 
 use Psr\Http\Message\RequestInterface;

--- a/src/EventDispatcher/AbstractGuzzleHttpEvent.php
+++ b/src/EventDispatcher/AbstractGuzzleHttpEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\EventDispatcher;
 
 use GuzzleHttp\Psr7\Request;

--- a/src/Handler/CacheTrait.php
+++ b/src/Handler/CacheTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\Handler;
 
 use GuzzleHttp\Promise\FulfilledPromise;
@@ -75,7 +77,7 @@ trait CacheTrait
                 array_keys($request->getHeaders()),
                 function ($header) use ($vary) {
                     return 0 !== stripos($header, 'x-')
-                        || array_key_exists($header, $vary)
+                        || \array_key_exists($header, $vary)
                     ;
                 }
             )
@@ -95,7 +97,7 @@ trait CacheTrait
             $cacheControl = $response->getHeader('Cache-Control')[0];
 
             if (preg_match('`max-age=(\d+)`', $cacheControl, $match)) {
-                return intval($match[1]);
+                return \intval($match[1]);
             }
         }
 
@@ -159,13 +161,13 @@ trait CacheTrait
         }
 
         $cacheKey = self::getKey($request);
-        if (is_null($cachedContent = $this->cache->get($cacheKey))) {
+        if (\is_null($cachedContent = $this->cache->get($cacheKey))) {
             return null;
         }
 
         $cached = unserialize($cachedContent);
         foreach ($cached as $value) {
-            if (is_null($value)) {
+            if (\is_null($value)) {
                 return null;
             }
         }
@@ -191,13 +193,13 @@ trait CacheTrait
      */
     public function __invoke(RequestInterface $request, array $options): PromiseInterface
     {
-        if (is_null($this->cache)) {
+        if (\is_null($this->cache)) {
             return parent::__invoke($request, $options);
         }
 
         // user want to force cache reload
         // so we remove existing cache
-        if (array_key_exists('cache_force', $options)) {
+        if (\array_key_exists('cache_force', $options)) {
             $this->cache->remove(self::getKey($request));
         }
 
@@ -236,7 +238,7 @@ trait CacheTrait
      */
     protected function isSupportedMethod(RequestInterface $request)
     {
-        return in_array(strtoupper($request->getMethod()), self::$methods);
+        return \in_array(strtoupper($request->getMethod()), self::$methods);
     }
 
     /**

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\Handler;
 
 use GuzzleHttp\Handler\CurlFactory as GuzzleCurlFactory;
@@ -16,7 +18,7 @@ class CurlFactory extends GuzzleCurlFactory
 {
     public function release(EasyHandle $easy): void
     {
-        if (!is_null($easy->response)) {
+        if (!\is_null($easy->response)) {
             $easy->response->curlInfo = curl_getinfo($easy->handle);
         }
 

--- a/src/Handler/CurlHandler.php
+++ b/src/Handler/CurlHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\Handler;
 
 use GuzzleHttp\Handler\CurlHandler as GuzzleCurlHandler;

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\Handler;
 
 use GuzzleHttp\Handler\CurlMultiHandler as GuzzleCurlMultiHandler;

--- a/src/M6WebGuzzleHttpBundle.php
+++ b/src/M6WebGuzzleHttpBundle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle;
 
 use M6Web\Bundle\GuzzleHttpBundle\DependencyInjection\GuzzleHttpPass;

--- a/src/Middleware/EventDispatcherMiddleware.php
+++ b/src/Middleware/EventDispatcherMiddleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\Middleware;
 
 use GuzzleHttp\HandlerStack;

--- a/src/Middleware/HostForwarderMiddleware.php
+++ b/src/Middleware/HostForwarderMiddleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\Middleware;
 
 use GuzzleHttp\HandlerStack;

--- a/src/Middleware/MiddlewareInterface.php
+++ b/src/Middleware/MiddlewareInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\Middleware;
 
 use GuzzleHttp\HandlerStack;

--- a/tests/Units/Cache/InMemory.php
+++ b/tests/Units/Cache/InMemory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\tests\Units\Cache;
 
 class InMemory extends \atoum

--- a/tests/Units/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/tests/Units/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -382,7 +382,7 @@ class M6WebGuzzleHttpExtension extends \atoum
                 'test' => $client->getAsync('http://httpbin.org'),
                 'test2' => $client->getAsync('http://httpbin.org/ip'),
             ])
-            ->and($rep = Promise\unwrap($promises))
+            ->and($rep = Promise\Utils::unwrap($promises))
             ->then
                 ->mock($container->get('event_dispatcher'))
                     ->call('dispatch')
@@ -402,7 +402,7 @@ class M6WebGuzzleHttpExtension extends \atoum
                 'test' => $client->getAsync('http://httpbin.org'),
                 'test2' => $client->getAsync('http://httpbin.org/ip'),
             ])
-            ->and($rep = Promise\unwrap($promises))
+            ->and($rep = Promise\Utils::unwrap($promises))
             ->and($client2->get('http://httpbin.org'))
             ->then
                 ->mock($container->get('event_dispatcher'))

--- a/tests/Units/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/tests/Units/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\tests\Units\DependencyInjection;
 
 use GuzzleHttp\Promise;
@@ -614,7 +616,7 @@ class M6WebGuzzleHttpExtension extends \atoum
     {
         $extension = new TestedClass();
 
-        if (is_null($container)) {
+        if (\is_null($container)) {
             $container = $this->getContainerBuilder();
         }
 

--- a/tests/Units/Handler/CurlMultiHandler.php
+++ b/tests/Units/Handler/CurlMultiHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\tests\Units\Handler;
 
 use GuzzleHttp\Psr7\Request;

--- a/tests/Units/Handler/FakeCurlMultiHandler.php
+++ b/tests/Units/Handler/FakeCurlMultiHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\tests\Units\Handler;
 
 use GuzzleHttp\Psr7\Request;

--- a/tests/Units/Middleware/EventDispatcherMiddleware.php
+++ b/tests/Units/Middleware/EventDispatcherMiddleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\tests\Units\Middleware;
 
 use M6Web\Bundle\GuzzleHttpBundle\EventDispatcher\GuzzleHttpErrorEvent;

--- a/tests/Units/Middleware/HostForwarderMiddleware.php
+++ b/tests/Units/Middleware/HostForwarderMiddleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\Bundle\GuzzleHttpBundle\tests\Units\Middleware;
 
 use M6Web\Bundle\GuzzleHttpBundle\Middleware\HostForwarderMiddleware as Base;


### PR DESCRIPTION
## Why?

much cleanup, such nice

## How?

* dropped unsupported Symfony versions
* dropped unsupported PHP versions
* dropped Guzzle 6 as [it doesn't support PHP8](https://github.com/guzzle/guzzle#version-guidance)
* applied latest CS rules

Should be included in next major version
